### PR TITLE
docker: remove runtime Boost libs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,9 +62,6 @@ RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fast
 RUN apk --no-cache add \
   bash \
   curl \
-  boost-filesystem \
-  boost-system \
-  boost-thread \
   libevent \
   libzmq \
   sqlite-dev \


### PR DESCRIPTION
These are not required, and haven't been for some time. See similar upstream change:
https://github.com/ruimarinho/docker-bitcoin-core/pull/139