### PR TITLE
Add note about backup excluding blocks etc. to instructions

### DIFF
--- a/instructions.md
+++ b/instructions.md
@@ -21,3 +21,7 @@ Beginning with version **25.0.0.1**, pruning is now handled automatically depend
 Pruning is a process by which your node discards old blocks and transactions after it verifies them. Pruned nodes and archival nodes are both "full nodes" in that they are fully validating - they validate every block and transaction. Archival nodes store the entire blockchain and are useful to people interested in doing general or historical analysis, or being a provider of blockchain data to others (eg. a blockexplorer). They are also required for the best experience with many popular wallets and other Bitcoin tools.
 
 **If you choose to prune**, the target on your Start9 server is configurable and set by default to the minimum of 550MB (0.55 GB!), meaning the resulting blockchain will occupy a negligible amount of storage space. The maximum amount of blockchain data you can retain depends on the storage capacity your device. The config menu will not permit you to select a target that exceeds a certain percentage of your device's available capacity.  For most use cases, we recommend sticking with a very low pruning setting.
+
+## Backups
+
+When your Embassy backs up this service, it will *not* include the blocks, chainstate, or indexes, so you don't need to worry about it eating your backup drive if you run an archival node.


### PR DESCRIPTION
I had assumed that telling my Embassy to back up bitcoind would mean copying the entire set of block data to my backup drive.  I didn't want to do that since the Bitcoin blockchain is one of the most widely-replicated datasets in existence (and this is not my only node), so I would rather save the backup space.

Then I heard on a podcast that bitcoind doesn't back up the block data, and found [this code ignoring the block data](https://github.com/Start9Labs/bitcoind-wrapper/blob/3c152a1d5acd5367d5754fac79c8d8432badbab9/manager/src/main.rs#L417-L422).

Since this was my assumption, there may be other people who would assume this, so this edit to the instructions will at least make it clear without leaving the Start OS UI.