### PR TITLE
de-doublequote rpcuser and rpcpassword

### DIFF
--- a/startos/actions/generateRpcUserDependent.ts
+++ b/startos/actions/generateRpcUserDependent.ts
@@ -91,8 +91,8 @@ export const generateRpcUserDependent = sdk.Action.withInput(
         subc.exec([
           'python3',
           '/assets/rpcauth.py',
-          `"${username}"`,
-          `"${password}"`,
+          `${username}`,
+          `${password}`,
         ]),
     )
 


### PR DESCRIPTION
This seemed to be the issue since the quotes were not being presented to the user but were included in the rpcauth line generated in the bitcoin.conf file.