### PR TITLE
[040] set passthrough_rpccookie

### DIFF
--- a/startos/file-models/rpc-proxy.toml.ts
+++ b/startos/file-models/rpc-proxy.toml.ts
@@ -11,6 +11,7 @@ const shape = object({
   tor_proxy: string,
   tor_only: boolean,
   passthrough_rpcauth: string.optional(),
+  passthrough_rpccookie: string.optional(),
 })
 
 export const configToml = FileHelper.toml(

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -180,6 +180,7 @@ export const main = sdk.setupMain(async ({ effects, started }) => {
       tor_proxy: `${osIp}:9050`,
       tor_only: !!conf.onlynet,
       passthrough_rpcauth: `${rootDir}/bitcoin.conf`,
+      passthrough_rpccookie: `${rootDir}/${bitcoinConfDefaults.rpccookiefile}`,
     })
 
     await promises.chmod(configToml.path, 0o600)


### PR DESCRIPTION
Needed to passthrough cookie auth to btc-rpc-proxy